### PR TITLE
Make FORCE_EVAL a no-op on wasm.

### DIFF
--- a/src/internal/libm.h
+++ b/src/internal/libm.h
@@ -60,6 +60,13 @@ union ldshape {
 #error Unsupported long double representation
 #endif
 
+#ifdef __wasm__
+/*
+ * wasm doesn't have user-accessible floating point exceptions, so there's
+ * no advantage to forcing floating-point expression evaluations.
+ */
+#define FORCE_EVAL(x) (x)
+#else
 #define FORCE_EVAL(x) do {                        \
 	if (sizeof(x) == sizeof(float)) {         \
 		volatile float __x;               \
@@ -72,6 +79,7 @@ union ldshape {
 		__x = (x);                        \
 	}                                         \
 } while(0)
+#endif
 
 /* Get two 32 bit ints from a double.  */
 #define EXTRACT_WORDS(hi,lo,d)                    \


### PR DESCRIPTION
WebAssembly doesn't have user-accessible floating point exceptions, so
there's no advantage to forcing floating-point expression evaluations.

This is a port of a similar patch in Emscripten's musl tree.

That said, this is otherwise target-independent code, and I don't know
whether upstream musl will be interested in such a change.
